### PR TITLE
OriginChain is not needed in Handler.create function

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -36,7 +36,7 @@ export default class Container {
     const handler = Handlers.create(
       repositories,
       config.facilitator.auxChainId,
-     mosaicAuxChain.contractAddresses.origin.ostEIP20GatewayAddress as string,
+      mosaicAuxChain.contractAddresses.origin.ostEIP20GatewayAddress as string,
     );
     const transactionHandler = new TransactionHandler(
       handler,

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -32,11 +32,10 @@ export default class Container {
     const config = configFactory.getConfig();
     Logger.debug('Config loaded successfully.');
     const repositories = await Repositories.create(config.facilitator.database.path);
-    const mosaicAuxChain = config.mosaic.auxiliaryChains[originChain!];
+    const mosaicAuxChain = config.mosaic.auxiliaryChains[auxChainId!];
     const handler = Handlers.create(
       repositories,
       config.facilitator.auxChainId,
-      originChain!,
      mosaicAuxChain.contractAddresses.origin.ostEIP20GatewayAddress as string,
     );
     const transactionHandler = new TransactionHandler(

--- a/src/handlers/Handlers.ts
+++ b/src/handlers/Handlers.ts
@@ -30,7 +30,6 @@ export default class Handlers {
    *
    * @param repos Repository container.
    * @param auxChainId ID of auxiliary chain.
-   * @param originChain Origin chain identifier.
    * @param gatewayAddress Origin chain gateway address.
    * @return Different kinds of transaction handlers.
    */


### PR DESCRIPTION
PR contains below:

- Handler.create function doesn't need origin chain argument. It's being removed.
- Documentation is updated

Fixes #165 
